### PR TITLE
added python examples to swagger docs

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -25,6 +25,11 @@ app = FastAPI(
     description=settings.DESCRIPTION
     + f"""
 
+## Using this Page
+
+Sections below can be expanded to see detailed information about each endpoint, including parameters, response formats, and example usage.
+The "Try it out" feature allows you to interactively test endpoints directly from the documentation.
+
 ## Automatic Pagination
 
 When a query would return more than {settings.AUTO_PAGINATION_THRESHOLD} records and no explicit limit is
@@ -32,7 +37,6 @@ provided, the API will automatically paginate results to return {settings.AUTO_P
 at a time. The response will include pagination metadata with links to navigate
 to next and previous pages.
 
-This threshold can be configured using the AUTO_PAGINATION_THRESHOLD environment variable.
 """,
     version=settings.VERSION,
     lifespan=lifespan,

--- a/app/routers/metadata.py
+++ b/app/routers/metadata.py
@@ -13,18 +13,43 @@ async def get_metadata(
     column: OEDColumn,
     db: Database = Depends(get_db),
 ) -> OEDColumnValues:
-    """
-    Get distinct values for a specified column.
+    r"""
+Get distinct values for a specified column.
 
-    This endpoint returns a list of all distinct values for a specified column
-    in the OED data set. This is useful to inspect what values can be used
-    for a more targeted download.
+This endpoint returns a list of all distinct values for a specified column
+in the OED data set. This is useful to inspect what values can be used
+for a more targeted download.
 
-    Example query:
+### URL examples
 
-    - /api/v1/metadata?column=organism
+- /api/v1/metadata?column=organism
 
-    - /api/v1/metadata?column=ec
+- /api/v1/metadata?column=ec
+
+### Python example
+
+```python
+import requests
+
+# Get distinct organism values to aid in filtering
+response = requests.get("https://fastapi.openenzymedb.mmli1.ncsa.illinois.edu/api/v1/metadata", params={"column": "organism"})
+
+if response.status_code == 200:
+    organism_data = response.json()
+    organisms = organism_data["values"]
+    print(f"Found {len(organisms)} distinct organism values")
+    print("Sample organisms:")
+    for organism in organisms[:5]:  # Display first 5 organisms
+        print(f"- {organism}")
+    # Sample output might include:
+    # - Trichoderma viride
+    # - Paenibacillus thiaminolyticus
+    # - Naegleria fowleri
+    # - Rhodococcus rhodochrous
+    # - Echinosophora koreensis
+else:
+    print(f"Error: {response.status_code} - {response.text}")
+```
     """
     try:
         values = await get_column_values(db, column=column.value)


### PR DESCRIPTION
We'd like OED users to have access to sample python code for calling the API.

There are currently nice examples in the README file, but the README file is written for people who are cloning this repo and running it locally. We expect many OED users would rather use the hosted API.

This PR therefore adds python examples to the swagger page. Screenshots are below.

<img width="1447" height="1398" alt="image" src="https://github.com/user-attachments/assets/4b9abda1-9353-4bc9-a4eb-fbe8be0c5e1c" />

<img width="1455" height="1414" alt="image" src="https://github.com/user-attachments/assets/6a026820-93c0-4bac-9ac8-f1fa5a60cdce" />
<img width="1456" height="835" alt="image" src="https://github.com/user-attachments/assets/a1971243-75a7-4213-bfaf-843ae7174941" />

Ideally we'd DRY this up, but we need a very quick solution for this week.